### PR TITLE
Added .NET core project structure

### DIFF
--- a/EthSharp/EthSharp.ContractDevelopment/EthSharp.ContractDevelopment.Core.csproj
+++ b/EthSharp/EthSharp.ContractDevelopment/EthSharp.ContractDevelopment.Core.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Data.HashFunction.Core" Version="2.0.0-ci-00012" />
+    <PackageReference Include="System.Data.HashFunction.xxHash" Version="2.0.0-ci-00012" />
+  </ItemGroup>
+</Project>

--- a/EthSharp/EthSharp.ContractDevelopment/EthSharp.ContractDevelopment.Core.csproj.nuget.g.props
+++ b/EthSharp/EthSharp.ContractDevelopment/EthSharp.ContractDevelopment.Core.csproj.nuget.g.props
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">/home/mike/dev/ethsharp-compiler/EthSharp/Ethsharp.ContractDevelopment.Core/obj/project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">/home/mike/.nuget/packages/</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">/home/mike/.nuget/packages/;/usr/share/dotnet/sdk/NuGetFallbackFolder</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">4.3.0</NuGetToolVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+</Project>

--- a/EthSharp/EthSharp.Core.sln
+++ b/EthSharp/EthSharp.Core.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.3
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ethsharp.Core", "EthSharp\EthSharp.Core.csproj", "{8C016E48-27D6-4FAB-9C3F-22D6EC8CECF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EthSharp.ContractDevelopment.Core", "EthSharp.ContractDevelopment\EthSharp.ContractDevelopment.Core.csproj", "{102E32D0-2ADB-4D51-9177-9715590000F8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8C016E48-27D6-4FAB-9C3F-22D6EC8CECF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C016E48-27D6-4FAB-9C3F-22D6EC8CECF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C016E48-27D6-4FAB-9C3F-22D6EC8CECF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C016E48-27D6-4FAB-9C3F-22D6EC8CECF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{102E32D0-2ADB-4D51-9177-9715590000F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{102E32D0-2ADB-4D51-9177-9715590000F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{102E32D0-2ADB-4D51-9177-9715590000F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{102E32D0-2ADB-4D51-9177-9715590000F8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {569359C0-D45A-4A11-9256-092B86AC5066}
+	EndGlobalSection
+EndGlobal

--- a/EthSharp/EthSharp/EthSharp.Core.csproj
+++ b/EthSharp/EthSharp/EthSharp.Core.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\EthSharp.ContractDevelopment\EthSharp.ContractDevelopment.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Properties\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.3.0-beta1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.2" />
+    <PackageReference Include="NStratis.HashLib" Version="1.0.0.1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
I am working with Linux, so it was a no brainer for me to start by creating a cross-platform structure.

Added a parallel project structure to be able to compile using .NET Core under linux. Existing project files left untouched.

Compiles and runs under .NET Core 2.0, in Ubuntu 17.04.

.NET Core works on Visual Studio 2015 and up, and is cross platform, so it might be a good idea to dump .NET Framework completely and move to .NET Core. I can volunteer to completely replace the existing project structure, and make sure everything works in Visual Studio too, if you would wish to do so.

If you are not willing to dump .NET Framework yet, this pull request could still be useful for other developers using Linux or OSx.
Feel free to reject if you feel like it is not needed, I will than keep it only in my fork.