### PR TITLE
Feature/manage allowed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -300,3 +300,4 @@ __pycache__/
 
 # Visual Studio Code
 .vscode
+EthSharp/EthSharp/test.txt

--- a/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
+++ b/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using EthSharp.ContractDevelopment;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace EthSharp.Compiler
+{
+    public class EthSharpAllowedTypesVisitor : CSharpSyntaxVisitor
+    {
+        private static readonly Dictionary<string, bool> AllowedTypes = new Dictionary<string, bool>
+        {
+            {typeof(UInt256).Name, true}
+        };
+
+        private string ExceptionMessage => "Type not supported. Currently supported types: " + String.Join(", ", AllowedTypes.Keys);
+
+        private bool TypeAllowed(TypeSyntax type)
+        {
+            return AllowedTypes.ContainsKey(type.GetText().ToString().Trim());
+        }
+
+
+        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            foreach (var property in node.GetProperties())
+            {
+                if (!TypeAllowed(property.Type))
+                    throw new NotImplementedException(ExceptionMessage); // TODO: Make these errors explicit
+            }
+            foreach (var field in node.GetFields())
+            {
+                if (!TypeAllowed(field.Declaration.Type))
+                    throw new NotImplementedException(ExceptionMessage);
+            }
+            foreach (var method in node.GetMethods())
+            {
+                method.Accept(this);
+            }
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            node.ParameterList.Accept(this);
+            node.Body.Accept(this);
+        }
+
+        public override void VisitParameterList(ParameterListSyntax node)
+        {
+            foreach (var parameter in node.Parameters)
+            {
+                if (!TypeAllowed(parameter.Type))
+                    throw new NotImplementedException(ExceptionMessage);
+            }
+        }
+
+        public override void VisitBlock(BlockSyntax node)
+        {
+            foreach (var statement in node.Statements)
+            {
+                statement.Accept(this);
+            }
+        }
+    }
+}

--- a/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
+++ b/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
@@ -10,16 +10,16 @@ namespace EthSharp.Compiler
 {
     public class EthSharpAllowedTypesVisitor : CSharpSyntaxVisitor
     {
-        private static readonly Dictionary<string, bool> AllowedTypes = new Dictionary<string, bool>
+        private static readonly HashSet<string> AllowedTypes = new HashSet<string>
         {
-            {typeof(UInt256).Name, true}
+            typeof(UInt256).Name
         };
 
-        private string ExceptionMessage => "Type not supported. Currently supported types: " + String.Join(", ", AllowedTypes.Keys);
+        private string ExceptionMessage => "Type not supported. Currently supported types: " + String.Join(", ", AllowedTypes);
 
         private bool TypeAllowed(TypeSyntax type)
         {
-            return AllowedTypes.ContainsKey(type.GetText().ToString().Trim());
+            return AllowedTypes.Contains(type.GetText().ToString().Trim());
         }
 
 

--- a/EthSharp/EthSharp/Compiler/EthSharpCompiler.cs
+++ b/EthSharp/EthSharp/Compiler/EthSharpCompiler.cs
@@ -26,6 +26,9 @@ namespace EthSharp.Compiler
         {
             // for now just assume one class
             InitializeContext();
+
+            Context.RootClass.Accept(new EthSharpAllowedTypesVisitor()); // parse class and throw exception if any unexpected types used
+
             Dictionary<byte[], PropertyDeclarationSyntax> propertyGetters = Context.RootClass.GetProperties().ToDictionary(x => x.GetGetterAbiSignature(), x => x);
             Dictionary<byte[], MethodDeclarationSyntax> methods = Context.RootClass.GetPublicMethods().ToDictionary(x => x.GetAbiSignature(), x => x);
             Dictionary<byte[], EthSharpAssemblyItem> publicMethodEntryPoints = new Dictionary<byte[], EthSharpAssemblyItem>();

--- a/EthSharp/EthSharp/Compiler/Extensions.cs
+++ b/EthSharp/EthSharp/Compiler/Extensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using EthSharp.ContractDevelopment;
 using EthSharp.Hashing;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -25,6 +26,11 @@ namespace EthSharp.Compiler
         public static IList<PropertyDeclarationSyntax> GetProperties(this ClassDeclarationSyntax classDeclarationSyntax)
         {
             return classDeclarationSyntax.Members.OfType<PropertyDeclarationSyntax>().ToList();
+        }
+
+        public static IList<FieldDeclarationSyntax> GetFields(this ClassDeclarationSyntax fieldDeclarationSyntax)
+        {
+            return fieldDeclarationSyntax.Members.OfType<FieldDeclarationSyntax>().ToList();
         }
 
         public static string GetExternalSignature(this MethodDeclarationSyntax method)

--- a/EthSharp/EthSharp/Program.cs
+++ b/EthSharp/EthSharp/Program.cs
@@ -54,7 +54,6 @@ namespace EthSharp
                 {
                     Console.WriteLine(evmByteCode.ByteCode.ToHexString());
                 }
-                Console.ReadKey();
             }
             else
             {


### PR DESCRIPTION
Basic implementation of a syntax visitor - iterates over some parts of the syntax and checks that only allowed types are being used. 

Currently checks: 
-properties
-fields
-method parameters

In the future when more features are available, can improve to check in more places.

This will allow us to add the types to 1 place (the dictionary in the allowed types visitor) and they can be checked everywhere easily :)