### PR TITLE
AllowedTypesVisitor Tests

### DIFF
--- a/EthSharp/EthSharp.Tests/Compiler/EthSharpAllowedTypesVisitorTests.cs
+++ b/EthSharp/EthSharp.Tests/Compiler/EthSharpAllowedTypesVisitorTests.cs
@@ -11,7 +11,7 @@ namespace EthSharp.Tests.Compiler
         [Fact]
         public void can_use_allowed_types()
         {
-            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> {typeof(string).Name});
+            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> {typeof(String).Name});
 
             var tree = CSharpSyntaxTree.ParseText(@"
 using EthSharp.ContractDevelopment;
@@ -24,12 +24,12 @@ public class SimpleTest : Contract
     public String Test2(String parameter)
     {
         String x;
-        return Test() + ""1"";
+        return Test() + 1;
     }
 
     private String Test()
     {
-        return ""1"";
+        return 1;
     }
 }");
 
@@ -49,12 +49,12 @@ public class SimpleTest : Contract
     public UInt256 Test2(String parameter)
     {
         String x;
-        return Test() + ""1"";
+        return Test() + 1;
     }
 
     private String Test()
     {
-        return ""1"";
+        return 1;
     }
 }");
             Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
@@ -74,12 +74,12 @@ public class SimpleTest : Contract
     public String Test2(UInt256 parameter)
     {
         String x;
-        return Test() + ""1"";
+        return Test() + 1;
     }
 
     private String Test()
     {
-        return ""1"";
+        return 1;
     }
 }");
             Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
@@ -99,12 +99,12 @@ public class SimpleTest : Contract
     public String Test2(String parameter)
     {
         UInt256 x;
-        return Test() + ""1"";
+        return Test() + 1;
     }
 
     private String Test()
     {
-        return ""1"";
+        return 1;
     }
 }");
             Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
@@ -126,12 +126,12 @@ public class SimpleTest : Contract
     public String Test2(String parameter)
     {
         String x;
-        return Test() + ""1"";
+        return Test() + 1;
     }
 
     private String Test()
     {
-        return ""1"";
+        return 1;
     }
 }");
             Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
@@ -153,12 +153,12 @@ public class SimpleTest : Contract
     public String Test2(String parameter)
     {
         String x;
-        return Test() + ""1"";
+        return Test() + 1;
     }
 
     private String Test()
     {
-        return ""1"";
+        return 1;
     }
 }");
             Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));

--- a/EthSharp/EthSharp.Tests/Compiler/EthSharpAllowedTypesVisitorTests.cs
+++ b/EthSharp/EthSharp.Tests/Compiler/EthSharpAllowedTypesVisitorTests.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using EthSharp.Compiler;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace EthSharp.Tests.Compiler
+{
+    public class EthSharpAllowedTypesVisitorTests
+    {
+        [Fact]
+        public void can_use_allowed_types()
+        {
+            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> {typeof(string).Name});
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+using EthSharp.ContractDevelopment;
+
+public class SimpleTest : Contract
+{
+    private String y {get; set;}
+    private String z;
+
+    public String Test2(String parameter)
+    {
+        String x;
+        return Test() + ""1"";
+    }
+
+    private String Test()
+    {
+        return ""1"";
+    }
+}");
+
+            sut.Visit(tree.GetRoot());
+        }
+
+        [Fact]        
+        public void can_reject_not_allowed_type_in_method_return()
+        {
+            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> { typeof(string).Name });
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+using EthSharp.ContractDevelopment;
+
+public class SimpleTest : Contract
+{
+    public UInt256 Test2(String parameter)
+    {
+        String x;
+        return Test() + ""1"";
+    }
+
+    private String Test()
+    {
+        return ""1"";
+    }
+}");
+            Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
+
+        }
+
+        [Fact]
+        public void can_reject_not_allowed_type_in_method_parameter()
+        {
+            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> { typeof(string).Name });
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+using EthSharp.ContractDevelopment;
+
+public class SimpleTest : Contract
+{
+    public String Test2(UInt256 parameter)
+    {
+        String x;
+        return Test() + ""1"";
+    }
+
+    private String Test()
+    {
+        return ""1"";
+    }
+}");
+            Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
+
+        }
+
+        [Fact]
+        public void can_reject_not_allowed_type_in_local_variable()
+        {
+            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> { typeof(string).Name });
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+using EthSharp.ContractDevelopment;
+
+public class SimpleTest : Contract
+{
+    public String Test2(String parameter)
+    {
+        UInt256 x;
+        return Test() + ""1"";
+    }
+
+    private String Test()
+    {
+        return ""1"";
+    }
+}");
+            Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
+
+        }
+
+        [Fact]
+        public void can_reject_not_allowed_type_in_member_declaration()
+        {
+            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> { typeof(string).Name });
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+using EthSharp.ContractDevelopment;
+
+public class SimpleTest : Contract
+{
+    private UInt256 y;
+
+    public String Test2(String parameter)
+    {
+        String x;
+        return Test() + ""1"";
+    }
+
+    private String Test()
+    {
+        return ""1"";
+    }
+}");
+            Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
+
+        }
+
+        [Fact]
+        public void can_reject_not_allowed_type_in_property_declaration()
+        {
+            var sut = new EthSharpAllowedTypesVisitor(new HashSet<string> { typeof(string).Name });
+
+            var tree = CSharpSyntaxTree.ParseText(@"
+using EthSharp.ContractDevelopment;
+
+public class SimpleTest : Contract
+{
+    private UInt256 y {get; set;}
+
+    public String Test2(String parameter)
+    {
+        String x;
+        return Test() + ""1"";
+    }
+
+    private String Test()
+    {
+        return ""1"";
+    }
+}");
+            Assert.Throws<Exception>(() => sut.Visit(tree.GetRoot()));
+
+        }
+    }
+}

--- a/EthSharp/EthSharp.Tests/EVM/EvmProgram.cs
+++ b/EthSharp/EthSharp.Tests/EVM/EvmProgram.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using EthSharp;
 using EthSharp.Compiler;
 using EthSharp.ContractDevelopment;
 

--- a/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
+++ b/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using EthSharp.ContractDevelopment;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace EthSharp.Compiler

--- a/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
+++ b/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
@@ -31,7 +31,7 @@ namespace EthSharp.Compiler
 
         private void CheckIfTypeIsAllowed(TypeSyntax type)
         {
-            var typeName = type.GetText().ToString().Trim();
+            var typeName = type.GetText().ToString().Trim(); // TODO: handle primite types aliases, String and string for example
 
             if (!TypeAllowed(typeName))
             {

--- a/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
+++ b/EthSharp/EthSharp/Compiler/EthSharpAllowedTypesVisitor.cs
@@ -6,60 +6,64 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace EthSharp.Compiler
 {
-    public class EthSharpAllowedTypesVisitor : CSharpSyntaxVisitor
+    public class EthSharpAllowedTypesVisitor : CSharpSyntaxWalker
     {
-        private static readonly HashSet<string> AllowedTypes = new HashSet<string>
+        private static HashSet<string> AllowedTypes = new HashSet<string>
         {
             typeof(UInt256).Name
         };
 
         private string ExceptionMessage => "Type not supported. Currently supported types: " + String.Join(", ", AllowedTypes);
 
-        private bool TypeAllowed(TypeSyntax type)
-        {
-            return AllowedTypes.Contains(type.GetText().ToString().Trim());
+        public EthSharpAllowedTypesVisitor()
+        {            
         }
 
-
-        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+        public EthSharpAllowedTypesVisitor(HashSet<string> allowedTypes)
         {
-            foreach (var property in node.GetProperties())
+            AllowedTypes = allowedTypes;
+        }
+
+        private bool TypeAllowed(string typeName)
+        {
+            return AllowedTypes.Contains(typeName);
+        }
+
+        private void CheckIfTypeIsAllowed(TypeSyntax type)
+        {
+            var typeName = type.GetText().ToString().Trim();
+
+            if (!TypeAllowed(typeName))
             {
-                if (!TypeAllowed(property.Type))
-                    throw new NotImplementedException(ExceptionMessage); // TODO: Make these errors explicit
+                throw new Exception("[" + typeName + "] " + ExceptionMessage); // TODO: Make these errors explicit
             }
-            foreach (var field in node.GetFields())
-            {
-                if (!TypeAllowed(field.Declaration.Type))
-                    throw new NotImplementedException(ExceptionMessage);
-            }
-            foreach (var method in node.GetMethods())
-            {
-                method.Accept(this);
-            }
+        }
+        
+        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            CheckIfTypeIsAllowed(node.Declaration.Type);
+        }
+
+        public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            CheckIfTypeIsAllowed(node.Type);
+            base.VisitPropertyDeclaration(node);
+        }
+
+        public override void VisitParameter(ParameterSyntax node)
+        {
+            CheckIfTypeIsAllowed(node.Type);
         }
 
         public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
-            node.ParameterList.Accept(this);
-            node.Body.Accept(this);
+            CheckIfTypeIsAllowed(node.ReturnType);
+            base.VisitMethodDeclaration(node);
         }
 
-        public override void VisitParameterList(ParameterListSyntax node)
+        public override void VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
         {
-            foreach (var parameter in node.Parameters)
-            {
-                if (!TypeAllowed(parameter.Type))
-                    throw new NotImplementedException(ExceptionMessage);
-            }
-        }
-
-        public override void VisitBlock(BlockSyntax node)
-        {
-            foreach (var statement in node.Statements)
-            {
-                statement.Accept(this);
-            }
+            CheckIfTypeIsAllowed(node.Declaration.Type);            
         }
     }
 }

--- a/EthSharp/EthSharp/SimpleTest.cs
+++ b/EthSharp/EthSharp/SimpleTest.cs
@@ -3,7 +3,7 @@
 public class SimpleTest : Contract
 {
     public UInt256 Test2()
-    {        
+    {
         return Test() + 1;
     }
 

--- a/EthSharp/EthSharp/SimpleTest.cs
+++ b/EthSharp/EthSharp/SimpleTest.cs
@@ -3,7 +3,7 @@
 public class SimpleTest : Contract
 {
     public UInt256 Test2()
-    {
+    {        
         return Test() + 1;
     }
 


### PR DESCRIPTION
Hi, 

I created a set of tests for the allowed types visitor, also made the visitor inherit from CSharpSyntaxWalker to avoid the need to override method like "VisitBlock" the walker recurse all the sintax tree by itself, just need to call "base.VisitXXX" at the end of a node with child nodes. 

Please review and let me know if it needs any change, 

Thanks!